### PR TITLE
Benchmarks: Fix sinuous benchmarks and don't let cellx eat up all of our precious memory

### DIFF
--- a/bench/layers.js
+++ b/bench/layers.js
@@ -147,6 +147,11 @@ function runCellx(layers, done) {
   const solution = [end.a.get(), end.b.get(), end.c.get(), end.d.get()];
   const endTime = performance.now() - startTime;
 
+  start.a.dispose();
+  start.b.dispose();
+  start.c.dispose();
+  start.d.dispose();
+
   done(isSolution(layers, solution) ? endTime : -1);
 }
 

--- a/bench/layers.js
+++ b/bench/layers.js
@@ -7,7 +7,7 @@ import kleur from 'kleur';
 import * as cellx from 'cellx';
 import * as Sjs from 's-js';
 // @ts-expect-error
-import * as sinuous from 'sinuous/dist/observable.js';
+import { default as sinuous } from 'sinuous/dist/observable.js';
 import * as solid from './solid-js-baseline.js';
 import * as preact from '@preact/signals-core';
 import * as maverick from '../dist/prod/index.js';
@@ -41,8 +41,7 @@ async function main() {
     solid: { fn: runSolid, runs: [] },
     'preact/signals': { fn: runPreact, runs: [] },
     S: { fn: runS, runs: [] },
-    // Can't get it to work for some reason.
-    // sinuous: { fn: runSinuous, runs: [] },
+    sinuous: { fn: runSinuous, runs: [] },
   };
 
   for (const lib of Object.keys(report)) {

--- a/bench/layers.js
+++ b/bench/layers.js
@@ -55,6 +55,8 @@ async function main() {
       for (let j = 0; j < RUNS_PER_TIER; j += 1) {
         runs.push(await start(current.fn, layers));
       }
+      // Give cellx time to release its global pendingCells array
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
       current.runs[i] = avg(runs) * 1000;
     }


### PR DESCRIPTION
This pull request modifies the layers benchmarks in two ways:

 * The sinuous benchmark now works, the imports needed to be a bit different.

 * Add a small `setTimeout(..., 0)` breather between different benchmarks. On my machine running the benchmark crashed due to Node.js running out of memory. Turns out that cellx uses a global `pendingCells` array that's filled during processing and is released asynchronously in batches. Especially in the last 2500 tier the amount of memory retained by cellx tended to become over 4 gigabytes. It also made things a bit unfair for libraries benchmarked after cellx, as they had to deal with the bloated heap. The timeout lets cellx return the memory in time and the GC do its magic.

 * Update: After submitting a similar change to https://github.com/elbywan/hyperactiv I noticed that the cellx benchmark can be made to interfere with the other libraries' benchmarks even less by manually disposing the root cells after each cellx run. See also https://github.com/elbywan/hyperactiv/pull/28

Thank you for a great benchmark, it has been useful for gauging differences between approaches 🙂