### PR TITLE
benchmark not cheking corretness

### DIFF
--- a/bench/layers.js
+++ b/bench/layers.js
@@ -33,7 +33,7 @@ const SOLUTIONS = {
  * @param {number} layers
  * @param {number[]} answer
  */
-const isSolution = (layers, answer) => answer.every((_, i) => SOLUTIONS[layers][i]);
+const isSolution = (layers, answer) => answer.every((_, i) => SOLUTIONS[layers][i] === _);
 
 async function main() {
   const report = {


### PR DESCRIPTION
The current benchmark is using `.every` to just return truthy values, instead of really checking correct results.

This MR fixes that, otherwise the result will e true no matter what the library computed.